### PR TITLE
fix: 修复README中Star历史图表无法显示的问题

### DIFF
--- a/README.md
+++ b/README.md
@@ -815,4 +815,4 @@ curl http://localhost:8888/api/health
 
 ## ⭐ Star 历史
 
-[![Star History Chart](https://api.star-history.com/svg?repos=fish2018/pansou&type=Date)](https://star-history.com/#fish2018/pansou&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=fish2018/pansou&type=Date)](https://star-history.dera.page/#fish2018/pansou&Date)


### PR DESCRIPTION
当前项目README中的Star历史图表已经无法正常显示，原因是GitHub的Stargazer接口限制导致原图表服务不可用。本PR将其切换到可正常使用的替代服务地址，保证Star历史图表能够继续展示，方便大家直观了解项目的成长情况。