### PR TITLE
feat: 添加ikantv网盘搜索插件

### DIFF
--- a/main.go
+++ b/main.go
@@ -51,6 +51,7 @@ import (
 	_ "pansou/plugin/hdr4k"
 	_ "pansou/plugin/huban"
 	_ "pansou/plugin/hunhepan"
+	_ "pansou/plugin/ikantv"
 	_ "pansou/plugin/javdb"
 	_ "pansou/plugin/jikepan"
 	_ "pansou/plugin/jsnoteclub"

--- a/plugin/ikantv/ikantv.go
+++ b/plugin/ikantv/ikantv.go
@@ -20,7 +20,7 @@ const (
 	defaultReferer = "https://api.naspt.vip/"
 	defaultTimeout = 30 * time.Second
 	defaultLimit   = 50
-	priority       = 2
+	priority       = 3
 )
 
 var allowedPans = map[string]struct{}{
@@ -38,8 +38,7 @@ type IkanTVAsyncPlugin struct {
 	*plugin.BaseAsyncPlugin
 }
 
-// NewIkanTVAsyncPlugin 创建爱看搜索插件。
-// 优先级 2：自有片库、结构化 API；标准网盘源，启用 Service 层过滤。
+// NewIkanTVAsyncPlugin 创建爱看搜索插件
 func NewIkanTVAsyncPlugin() *IkanTVAsyncPlugin {
 	return &IkanTVAsyncPlugin{
 		BaseAsyncPlugin: plugin.NewBaseAsyncPlugin(pluginName, priority),

--- a/plugin/ikantv/ikantv.go
+++ b/plugin/ikantv/ikantv.go
@@ -1,0 +1,260 @@
+package ikantv
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"pansou/model"
+	"pansou/plugin"
+	"pansou/util/json"
+)
+
+const (
+	pluginName     = "ikantv"
+	searchAPI      = "https://api.naspt.vip/api/open/pansou/search"
+	defaultReferer = "https://api.naspt.vip/"
+	defaultTimeout = 30 * time.Second
+	defaultLimit   = 50
+	priority       = 2
+)
+
+var allowedPans = map[string]struct{}{
+	"quark": {}, "uc": {}, "baidu": {}, "aliyun": {}, "guangya": {},
+	"xunlei": {}, "tianyi": {}, "115": {}, "123": {}, "mobile": {},
+	"pikpak": {}, "magnet": {}, "ed2k": {},
+}
+
+func init() {
+	plugin.RegisterGlobalPlugin(NewIkanTVAsyncPlugin())
+}
+
+// IkanTVAsyncPlugin 爱看公开搜索异步插件
+type IkanTVAsyncPlugin struct {
+	*plugin.BaseAsyncPlugin
+}
+
+// NewIkanTVAsyncPlugin 创建爱看搜索插件。
+// 优先级 2：自有片库、结构化 API；标准网盘源，启用 Service 层过滤。
+func NewIkanTVAsyncPlugin() *IkanTVAsyncPlugin {
+	return &IkanTVAsyncPlugin{
+		BaseAsyncPlugin: plugin.NewBaseAsyncPlugin(pluginName, priority),
+	}
+}
+
+// Search 执行搜索并返回结果（兼容性方法）
+func (p *IkanTVAsyncPlugin) Search(keyword string, ext map[string]interface{}) ([]model.SearchResult, error) {
+	result, err := p.SearchWithResult(keyword, ext)
+	if err != nil {
+		return nil, err
+	}
+	return result.Results, nil
+}
+
+// SearchWithResult 执行搜索并返回包含 IsFinal 标记的结果
+func (p *IkanTVAsyncPlugin) SearchWithResult(keyword string, ext map[string]interface{}) (model.PluginSearchResult, error) {
+	return p.AsyncSearchWithResult(keyword, p.doSearch, p.MainCacheKey, ext)
+}
+
+// doSearch 实际搜索实现
+func (p *IkanTVAsyncPlugin) doSearch(client *http.Client, keyword string, ext map[string]interface{}) ([]model.SearchResult, error) {
+	searchURL := fmt.Sprintf("%s?kw=%s&limit=%d", searchAPI, url.QueryEscape(keyword), defaultLimit)
+	if titleEn, ok := ext["title_en"].(string); ok && titleEn != "" {
+		searchURL += "&title_en=" + url.QueryEscape(titleEn)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, searchURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] 创建请求失败: %w", p.Name(), err)
+	}
+
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/91.0.4472.124 Safari/537.36")
+	req.Header.Set("Accept", "application/json, text/plain, */*")
+	req.Header.Set("Accept-Language", "zh-CN,zh;q=0.9,en;q=0.8")
+	req.Header.Set("Connection", "keep-alive")
+	req.Header.Set("Referer", defaultReferer)
+
+	resp, err := p.doRequestWithRetry(req, client)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] 搜索请求失败: %w", p.Name(), err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("[%s] 请求返回状态码: %d", p.Name(), resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("[%s] 读取响应失败: %w", p.Name(), err)
+	}
+
+	var apiResp apiResponse
+	if err := json.Unmarshal(body, &apiResp); err != nil {
+		return nil, fmt.Errorf("[%s] JSON解析失败: %w", p.Name(), err)
+	}
+	if apiResp.Code != 0 {
+		return nil, fmt.Errorf("[%s] API错误: %s", p.Name(), apiResp.Message)
+	}
+
+	results := convertResults(apiResp.Data)
+	return plugin.FilterResultsByKeyword(results, keyword), nil
+}
+
+func convertResults(items []apiItem) []model.SearchResult {
+	results := make([]model.SearchResult, 0, len(items))
+	for _, item := range items {
+		result, ok := convertResult(item)
+		if !ok {
+			continue
+		}
+		results = append(results, result)
+	}
+	return results
+}
+
+func convertResult(item apiItem) (model.SearchResult, bool) {
+	links := convertLinks(item.Links)
+	if len(links) == 0 {
+		return model.SearchResult{}, false
+	}
+
+	itemID := strings.TrimSpace(item.UniqueID)
+	if itemID == "" {
+		itemID = strings.TrimSpace(item.MessageID)
+	}
+	if itemID == "" {
+		return model.SearchResult{}, false
+	}
+	itemID = strings.TrimPrefix(itemID, pluginName+"-")
+
+	return model.SearchResult{
+		MessageID: item.MessageID,
+		UniqueID:  fmt.Sprintf("%s-%s", pluginName, itemID),
+		Channel:   "",
+		Datetime:  parseDatetime(item.Datetime),
+		Title:     item.Title,
+		Content:   item.Content,
+		Links:     links,
+		Tags:      item.Tags,
+		Images:    item.Images,
+	}, true
+}
+
+func convertLinks(raw []apiLink) []model.Link {
+	links := make([]model.Link, 0, len(raw))
+	for _, link := range raw {
+		pan := strings.ToLower(strings.TrimSpace(link.Type))
+		if _, ok := allowedPans[pan]; !ok {
+			continue
+		}
+		href := strings.TrimSpace(link.URL)
+		if href == "" || !isValidURL(pan, href) {
+			continue
+		}
+		links = append(links, model.Link{
+			Type:      pan,
+			URL:       href,
+			Password:  link.Password,
+			Datetime:  parseDatetime(link.Datetime),
+			WorkTitle: link.WorkTitle,
+		})
+	}
+	return links
+}
+
+func isValidURL(pan, raw string) bool {
+	if pan == "magnet" {
+		return strings.HasPrefix(strings.ToLower(raw), "magnet:?")
+	}
+	if pan == "ed2k" {
+		return strings.HasPrefix(strings.ToLower(raw), "ed2k://")
+	}
+	u, err := url.Parse(raw)
+	if err != nil || u.Host == "" {
+		return false
+	}
+	return strings.HasPrefix(u.Scheme, "http")
+}
+
+func parseDatetime(value string) time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}
+	}
+	if t, err := time.Parse(time.RFC3339, value); err == nil {
+		return t
+	}
+	if t, err := time.Parse("2006-01-02T15:04:05Z07:00", value); err == nil {
+		return t
+	}
+	return time.Time{}
+}
+
+func (p *IkanTVAsyncPlugin) doRequestWithRetry(req *http.Request, client *http.Client) (*http.Response, error) {
+	maxRetries := 3
+	var lastErr error
+
+	for i := 0; i < maxRetries; i++ {
+		if i > 0 {
+			backoff := time.Duration(1<<uint(i-1)) * 200 * time.Millisecond
+			time.Sleep(backoff)
+		}
+
+		reqClone := req.Clone(req.Context())
+		resp, err := client.Do(reqClone)
+		if err == nil && resp.StatusCode == 200 {
+			return resp, nil
+		}
+
+		if resp != nil {
+			resp.Body.Close()
+		}
+		lastErr = err
+		if lastErr == nil {
+			lastErr = fmt.Errorf("status %d", statusCode(resp))
+		}
+	}
+
+	return nil, fmt.Errorf("重试 %d 次后仍然失败: %w", maxRetries, lastErr)
+}
+
+func statusCode(resp *http.Response) int {
+	if resp == nil {
+		return 0
+	}
+	return resp.StatusCode
+}
+
+type apiResponse struct {
+	Code    int       `json:"code"`
+	Message string    `json:"message"`
+	Data    []apiItem `json:"data"`
+}
+
+type apiItem struct {
+	MessageID string    `json:"message_id"`
+	UniqueID  string    `json:"unique_id"`
+	Channel   string    `json:"channel"`
+	Datetime  string    `json:"datetime"`
+	Title     string    `json:"title"`
+	Content   string    `json:"content"`
+	Tags      []string  `json:"tags"`
+	Images    []string  `json:"images"`
+	Links     []apiLink `json:"links"`
+}
+
+type apiLink struct {
+	Type      string `json:"type"`
+	URL       string `json:"url"`
+	Password  string `json:"password"`
+	Datetime  string `json:"datetime"`
+	WorkTitle string `json:"work_title"`
+}

--- a/plugin/ikantv/ikantv_test.go
+++ b/plugin/ikantv/ikantv_test.go
@@ -1,0 +1,92 @@
+package ikantv
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestConvertResultKeepsOrderAndFields(t *testing.T) {
+	items := []apiItem{
+		{
+			MessageID: "resource-1",
+			UniqueID:  "ikantv-resource-1",
+			Channel:   "should-be-cleared",
+			Datetime:  "2026-08-18T01:26:00+08:00",
+			Title:     "藏锋 更至04集 2026-08-18更新 【免会员保存/观看】",
+			Content:   "藏锋 更至04集 2026-08-18更新 【免会员保存/观看】",
+			Tags:      []string{"最新", "免会员保存"},
+			Links: []apiLink{
+				{Type: "xunlei", URL: "https://pan.xunlei.com/s/own", WorkTitle: "藏锋 更至04集 2026-08-18更新 【免会员保存/观看】"},
+				{Type: "quark", URL: "https://pan.quark.cn/s/own", WorkTitle: "藏锋 更至04集 2026-08-18更新"},
+			},
+		},
+		{
+			UniqueID: "ikantv-resource-2",
+			Title:    "藏锋 全24集 全 2026-08-18更新",
+			Links: []apiLink{
+				{Type: "quark", URL: "https://pan.quark.cn/s/full"},
+			},
+		},
+	}
+
+	results := convertResults(items)
+	if len(results) != 2 {
+		t.Fatalf("got %d results", len(results))
+	}
+	if results[0].Title != items[0].Title {
+		t.Fatalf("order/title changed: %s", results[0].Title)
+	}
+	if results[0].Channel != "" {
+		t.Fatalf("channel must be empty, got %q", results[0].Channel)
+	}
+	if results[0].UniqueID != "ikantv-resource-1" {
+		t.Fatalf("unique id: %s", results[0].UniqueID)
+	}
+	if len(results[0].Links) != 2 {
+		t.Fatalf("links: %d", len(results[0].Links))
+	}
+	if !strings.Contains(results[0].Links[0].WorkTitle, "免会员保存") {
+		t.Fatalf("xunlei work_title lost badge: %s", results[0].Links[0].WorkTitle)
+	}
+	if strings.Contains(results[0].Links[1].WorkTitle, "免会员保存") {
+		t.Fatalf("quark work_title should not have badge")
+	}
+}
+
+func TestConvertResultDropsEmptyAndUnknownLinks(t *testing.T) {
+	item := apiItem{
+		UniqueID: "ikantv-resource-x",
+		Title:    "测试",
+		Links: []apiLink{
+			{Type: "others", URL: "https://example.com/s/x"},
+			{Type: "quark", URL: ""},
+		},
+	}
+	if _, ok := convertResult(item); ok {
+		t.Fatal("expected drop when no valid links")
+	}
+}
+
+func TestParseDatetimeRFC3339(t *testing.T) {
+	got := parseDatetime("2026-08-18T01:26:00+08:00")
+	if got.IsZero() {
+		t.Fatal("rfc3339 should parse")
+	}
+}
+
+func TestConvertResultKeepsVarietyDotTitle(t *testing.T) {
+	item := apiItem{
+		UniqueID: "ikantv-resource-v",
+		Title:    "花开锦绣 更至08.13期 2026-08-18更新",
+		Links: []apiLink{
+			{Type: "quark", URL: "https://pan.quark.cn/s/var"},
+		},
+	}
+	got, ok := convertResult(item)
+	if !ok {
+		t.Fatal("expected keep")
+	}
+	if got.Title != item.Title {
+		t.Fatalf("dot in variety title must be kept: %s", got.Title)
+	}
+}


### PR DESCRIPTION
感谢 pansou 一直以来对网盘搜索生态的维护，也参考了仓库里现有插件和开发指南来实现这一份。

## 插件说明

新增 **ikantv（爱看）** 搜索插件，对接公开接口，无需登录或 cookie：

`GET https://api.naspt.vip/api/open/pansou/search?kw=`

- 站点：https://ik.naspt.vip
- 资源来源：站内人工挑选、整理的优质网盘资源，以及 PT 优质资源上传
- 迅雷独家权益：资源可免会员保存 / 观看，享受会员同等能力，空间不限

## 实现

- 标准网盘插件：`NewBaseAsyncPlugin("ikantv", 3)`，不跳过 Service 层过滤
- 返回字段对齐 `model.SearchResult`（`unique_id`、`channel=""`、`links` 等）
- 支持夸克 / 百度 / 迅雷 / 阿里 / UC / 天翼 / 115 / 123 等常见网盘
- 已在本地对「藏锋」「花开锦绣」做过搜索验证

改动文件：

- `plugin/ikantv/ikantv.go`
- `plugin/ikantv/ikantv_test.go`
- `main.go`（空导入 `_ "pansou/plugin/ikantv"`）

若实现上有不规范的地方，麻烦指出，我跟着改。谢谢。